### PR TITLE
Score game async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ netgo.gorm.db
 
 # i dont want js to be dominant project language on gh... yeah i'm like that
 elm.js
+scoring-worker.js
 
 # hide env file secrets
 .env

--- a/backend/services/user_repository.go
+++ b/backend/services/user_repository.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 	"net-go/server/backend/model"
+
+	"gorm.io/gorm/clause"
 )
 
 /* interface */
@@ -37,14 +39,14 @@ func NewUserRepository(deps *UserRepoDeps) IUserRepository {
 
 func (u *UserRepository) FindByID(ctx context.Context, id uint) (*model.User, error) {
 	var user model.User
-	err := u.Db.First(&user, id).Error
+	err := u.Db.Preload(clause.Associations).First(&user, id).Error
 
 	return &user, err
 }
 
 func (u *UserRepository) FindByUsername(ctx context.Context, username string) (*model.User, error) {
 	var user model.User
-	err := u.Db.First(&user, "username = ?", username).Error
+	err := u.Db.Preload(clause.Associations).First(&user, "username = ?", username).Error
 
 	return &user, err
 }

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -342,13 +342,39 @@ initCurrentPage ( model, existingCmds ) =
     )
 
 
+-- SUBSCRIPTIONS --
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    case model.page of
+        NotFoundPage ->
+            Sub.none
+
+        HomePage pageModel ->
+            Sub.none
+
+        GameCreatePage pageModel ->
+            Sub.none
+
+        GamePlayPage pageModel ->
+            Sub.map GamePlayPageMsg (GamePlay.subscriptions pageModel)
+
+        SignUpPage pageModel ->
+            Sub.none
+
+        SignInPage pageModel ->
+            Sub.none
+
+
+-- MAIN --
+
 main : Program Bool Model Msg
 main =
     Browser.application
         { init = init
         , view = view
         , update = update
-        , subscriptions = \_ -> Sub.none
+        , subscriptions = subscriptions
         , onUrlRequest = LinkClicked
         , onUrlChange = UrlChanged
         }

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -342,7 +342,9 @@ initCurrentPage ( model, existingCmds ) =
     )
 
 
+
 -- SUBSCRIPTIONS --
+
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
@@ -366,7 +368,9 @@ subscriptions model =
             Sub.none
 
 
+
 -- MAIN --
+
 
 main : Program Bool Model Msg
 main =

--- a/frontend/src/Model/Move.elm
+++ b/frontend/src/Model/Move.elm
@@ -28,6 +28,7 @@ moveDecoder =
         , Decode.map Pass (field "piece" Model.Piece.pieceDecoder)
         ]
 
+
 moveEncoder : Move -> Encode.Value
 moveEncoder move =
     case move of

--- a/frontend/src/Model/Move.elm
+++ b/frontend/src/Model/Move.elm
@@ -23,20 +23,10 @@ type Move
 
 moveDecoder : Decoder Move
 moveDecoder =
-    field "moveType" int
-        |> Decode.andThen
-            (\moveType ->
-                case moveType of
-                    0 ->
-                        Decode.map2 Play (field "piece" Model.Piece.pieceDecoder) int
-
-                    1 ->
-                        Decode.map Pass (field "piece" Model.Piece.pieceDecoder)
-
-                    _ ->
-                        Decode.fail ("No JSON decode mapping for MoveType " ++ String.fromInt moveType)
-            )
-
+    Decode.oneOf
+        [ Decode.map2 Play (field "piece" Model.Piece.pieceDecoder) int
+        , Decode.map Pass (field "piece" Model.Piece.pieceDecoder)
+        ]
 
 moveEncoder : Move -> Encode.Value
 moveEncoder move =

--- a/frontend/src/Page/GamePlay.elm
+++ b/frontend/src/Page/GamePlay.elm
@@ -1,4 +1,4 @@
-module Page.GamePlay exposing (Model, Msg, init, isInnerCell, update, view, subscriptions)
+module Page.GamePlay exposing (Model, Msg, init, isInnerCell, subscriptions, update, view)
 
 import API.Games exposing (getGame)
 import Array
@@ -7,6 +7,7 @@ import Error exposing (stringFromHttpError)
 import Html exposing (..)
 import Html.Attributes exposing (class, href, src, style)
 import Html.Events exposing (onClick)
+import Json.Decode exposing (Value)
 import Logic.Rules exposing (..)
 import Logic.Scoring exposing (scoreGame)
 import Model.Board as Board exposing (..)
@@ -15,11 +16,10 @@ import Model.Game as Game exposing (..)
 import Model.Move as Move exposing (..)
 import Model.Piece as Piece exposing (..)
 import Model.Score as Score
-import Json.Decode exposing (Value)
 import Random
 import RemoteData exposing (WebData)
 import Route exposing (routeToString)
-import ScoringPorts exposing (sendScoreGame, receiveReturnedGame, decodeGameFromValue)
+import ScoringPorts exposing (decodeGameFromValue, receiveReturnedGame, sendScoreGame)
 import Svg exposing (circle, svg)
 import Svg.Attributes as SAtts
 
@@ -88,7 +88,7 @@ startScoring model forfeitColor =
               -- TODO: send game scored game to backend!
             )
 
-        (Just game, _) ->
+        ( Just game, _ ) ->
             -- trigger score calculation
             ( { model
                 | playState = CalculatingScore
@@ -98,7 +98,7 @@ startScoring model forfeitColor =
 
         _ ->
             -- should never happen; there must be a game if we're trying to score it
-            (model, Cmd.none)
+            ( model, Cmd.none )
 
 
 
@@ -203,15 +203,15 @@ viewAlert model =
                     div
                         [ class "bg-red-300 rounded p-2" ]
                         [ p [ class "font-bold" ]
-                              [ text ("Invalid move: " ++ errorMessage) ]
+                            [ text ("Invalid move: " ++ errorMessage) ]
                         ]
     in
     div
         []
-        ( List.map
-            (viewCreator)
-            [model.invalidMoveAlert
-            ,model.transportError
+        (List.map
+            viewCreator
+            [ model.invalidMoveAlert
+            , model.transportError
             ]
         )
 
@@ -552,12 +552,13 @@ update msg model =
                             Playing
             in
             ( { model
-                  | clientGameData = newGameData
-                  , transportError = transportError
-                  , playState = nextPlayState
+                | clientGameData = newGameData
+                , transportError = transportError
+                , playState = nextPlayState
               }
             , Cmd.none
             )
+
 
 endTurn : Model -> Cmd Msg
 endTurn model =
@@ -588,7 +589,10 @@ initialModel =
     , initialSeed = 0
     }
 
+
+
 -- SUBSCRIPTIONS --
+
 
 subscriptions : Model -> Sub Msg
 subscriptions model =

--- a/frontend/src/Page/GamePlay.elm
+++ b/frontend/src/Page/GamePlay.elm
@@ -1,4 +1,4 @@
-module Page.GamePlay exposing (Model, Msg, init, isInnerCell, update, view)
+module Page.GamePlay exposing (Model, Msg, init, isInnerCell, update, view, subscriptions)
 
 import API.Games exposing (getGame)
 import Array
@@ -530,8 +530,14 @@ initialModel : Model
 initialModel =
     { remoteGameData = RemoteData.Loading
     , clientGameData = Nothing
-    , activeTurn = False -- TODO colorChoice == Black
+    , activeTurn = False -- this gets updated when remote data loads
     , invalidMoveAlert = Nothing
     , playState = Playing
     , initialSeed = 0
     }
+
+-- SUBSCRIPTIONS --
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none -- TODO; finish

--- a/frontend/src/Page/GamePlay.elm
+++ b/frontend/src/Page/GamePlay.elm
@@ -550,13 +550,16 @@ update msg model =
 
                         _ ->
                             Playing
+
+                updatedModel =
+                    { model
+                        | clientGameData = newGameData
+                        , transportError = transportError
+                        , playState = nextPlayState
+                    }
             in
-            ( { model
-                | clientGameData = newGameData
-                , transportError = transportError
-                , playState = nextPlayState
-              }
-            , Cmd.none
+            ( updatedModel
+            , endTurn updatedModel
             )
 
 

--- a/frontend/src/Page/GamePlay.elm
+++ b/frontend/src/Page/GamePlay.elm
@@ -15,10 +15,11 @@ import Model.Game as Game exposing (..)
 import Model.Move as Move exposing (..)
 import Model.Piece as Piece exposing (..)
 import Model.Score as Score
+import Json.Decode exposing (Value)
 import Random
 import RemoteData exposing (WebData)
 import Route exposing (routeToString)
-import ScoringPorts exposing (sendScoreGame, receiveReturnedGame)
+import ScoringPorts exposing (sendScoreGame, receiveReturnedGame, decodeGameFromValue)
 import Svg exposing (circle, svg)
 import Svg.Attributes as SAtts
 
@@ -30,7 +31,7 @@ type Msg
     | CalculateGameScore Int
     | FetchGame String -- gameId
     | DataReceived (WebData Game)
-    | ReceiveScoredGame Game
+    | ReceiveScoredGame Value
 
 
 type PlayState
@@ -47,6 +48,7 @@ type alias Model =
     , clientGameData : Maybe Game
     , activeTurn : Bool
     , invalidMoveAlert : Maybe String
+    , transportError : Maybe String
     , initialSeed : Int
     , playState : PlayState
     }
@@ -91,11 +93,11 @@ startScoring model forfeitColor =
             ( { model
                 | playState = CalculatingScore
               }
-            , sendScoreGame game
+            , sendScoreGame (Game.gameEncoder game)
             )
 
         _ ->
-            -- should never happen
+            -- should never happen; there must be a game if we're trying to score it
             (model, Cmd.none)
 
 
@@ -110,7 +112,7 @@ view model =
         Just game ->
             case model.playState of
                 Playing ->
-                    gamePlayView game model.invalidMoveAlert model.activeTurn
+                    gamePlayView game model
 
                 CalculatingScore ->
                     -- TODO: this view is never showing... browser too busy?
@@ -125,14 +127,13 @@ view model =
                     loadingView
 
                 RemoteData.Failure error ->
-                    -- TODO: imporove
+                    -- TODO: improve
                     text ("Error fetching game: " ++ stringFromHttpError error)
 
                 _ ->
                     -- RemoteData.NotAsked + RemoteData.Success
                     -- niether of which should ever happen/reach here
-                    -- TODO: this will never happen? share case result w/ err
-                    text "Error"
+                    text "Unknown Error. Please refresh."
 
 
 loadingView : Html Msg
@@ -169,12 +170,12 @@ scoreView score playerColor =
         ]
 
 
-gamePlayView : Game -> Maybe String -> Bool -> Html Msg
-gamePlayView game invalidMoveAlert activeTurn =
+gamePlayView : Game -> Model -> Html Msg
+gamePlayView game model =
     div [ class "p-5 flex flex-col gap-4" ]
-        [ viewWaitForOpponent activeTurn
+        [ viewWaitForOpponent model.activeTurn
         , viewBuildBoard game
-        , viewAlert invalidMoveAlert
+        , viewAlert model
         , div [ class "flex gap-4" ]
             [ button
                 [ class "btn"
@@ -190,18 +191,29 @@ gamePlayView game invalidMoveAlert activeTurn =
         ]
 
 
-viewAlert : Maybe String -> Html Msg
-viewAlert error =
-    case error of
-        Nothing ->
-            text ""
+viewAlert : Model -> Html Msg
+viewAlert model =
+    let
+        viewCreator error =
+            case error of
+                Nothing ->
+                    text ""
 
-        Just errorMessage ->
-            div
-                [ class "bg-red-300 rounded p-2" ]
-                [ p [ class "font-bold" ]
-                    [ text ("Invalid move: " ++ errorMessage) ]
-                ]
+                Just errorMessage ->
+                    div
+                        [ class "bg-red-300 rounded p-2" ]
+                        [ p [ class "font-bold" ]
+                              [ text ("Invalid move: " ++ errorMessage) ]
+                        ]
+    in
+    div
+        []
+        ( List.map
+            (viewCreator)
+            [model.invalidMoveAlert
+            ,model.transportError
+            ]
+        )
 
 
 viewWaitForOpponent : Bool -> Html Msg
@@ -441,7 +453,7 @@ handleCalculateGameScore model seed =
 
         Just game ->
             ( model
-            , sendScoreGame game
+            , sendScoreGame (Game.gameEncoder game)
             )
 
 
@@ -492,19 +504,57 @@ update msg model =
 
                         _ ->
                             Nothing
+
+                transportError =
+                    case responseGame of
+                        RemoteData.Failure error ->
+                            Just (stringFromHttpError error)
+
+                        _ ->
+                            Nothing
             in
             ( { model
                 | remoteGameData = responseGame
                 , clientGameData = clientGameData
+                , transportError = transportError
                 , activeTurn = activeTurn
               }
             , Cmd.none
             )
 
-        ReceiveScoredGame game ->
+        ReceiveScoredGame encodedGame ->
+            let
+                decodedGame =
+                    decodeGameFromValue encodedGame
+
+                newGameData =
+                    case decodedGame of
+                        Ok game ->
+                            Just game
+
+                        _ ->
+                            model.clientGameData
+
+                transportError =
+                    case decodedGame of
+                        Err error ->
+                            Just (Json.Decode.errorToString error)
+
+                        _ ->
+                            Nothing
+
+                nextPlayState =
+                    case decodedGame of
+                        Ok game ->
+                            FinalScore game.score
+
+                        _ ->
+                            Playing
+            in
             ( { model
-                | clientGameData = Just game
-                , playState = FinalScore game.score
+                  | clientGameData = newGameData
+                  , transportError = transportError
+                  , playState = nextPlayState
               }
             , Cmd.none
             )
@@ -533,6 +583,7 @@ initialModel =
     , clientGameData = Nothing
     , activeTurn = False -- this gets updated when remote data loads
     , invalidMoveAlert = Nothing
+    , transportError = Nothing
     , playState = Playing
     , initialSeed = 0
     }

--- a/frontend/src/ScoringPorts.elm
+++ b/frontend/src/ScoringPorts.elm
@@ -1,4 +1,4 @@
-port module ScoringPorts exposing (sendScoreGame, receiveScoreGame)
+port module ScoringPorts exposing (decodeGameFromValue, sendScoreGame, returnScoreGame, receiveSentGame, receiveReturnedGame)
 
 import Model.Game as Game
 import Json.Decode exposing (Error(..), Value, decodeValue)
@@ -7,8 +7,11 @@ decodeGameFromValue : Value -> Result Error Game.Game
 decodeGameFromValue value =
     decodeValue Game.gameDecoder value
 
--- TODO: need 2 more? each needs a variant for subscription listening, and subscription sending
 
 port sendScoreGame : Value -> Cmd msg
 
-port receiveScoreGame : (Value -> msg) -> Sub msg
+port receiveSentGame : (Value -> msg) -> Sub msg
+
+port returnScoreGame : Value -> Cmd msg
+
+port receiveReturnedGame : (Value -> msg) -> Sub msg

--- a/frontend/src/ScoringPorts.elm
+++ b/frontend/src/ScoringPorts.elm
@@ -1,0 +1,14 @@
+port module ScoringPorts exposing (sendScoreGame, receiveScoreGame)
+
+import Model.Game as Game
+import Json.Decode exposing (Error(..), Value, decodeValue)
+
+decodeGameFromValue : Value -> Result Error Game.Game
+decodeGameFromValue value =
+    decodeValue Game.gameDecoder value
+
+-- TODO: need 2 more? each needs a variant for subscription listening, and subscription sending
+
+port sendScoreGame : Value -> Cmd msg
+
+port receiveScoreGame : (Value -> msg) -> Sub msg

--- a/frontend/src/ScoringPorts.elm
+++ b/frontend/src/ScoringPorts.elm
@@ -1,7 +1,8 @@
-port module ScoringPorts exposing (decodeGameFromValue, sendScoreGame, returnScoreGame, receiveSentGame, receiveReturnedGame)
+port module ScoringPorts exposing (decodeGameFromValue, receiveReturnedGame, receiveSentGame, returnScoreGame, sendScoreGame)
 
-import Model.Game as Game
 import Json.Decode exposing (Error(..), Value, decodeValue)
+import Model.Game as Game
+
 
 decodeGameFromValue : Value -> Result Error Game.Game
 decodeGameFromValue value =
@@ -10,8 +11,11 @@ decodeGameFromValue value =
 
 port sendScoreGame : Value -> Cmd msg
 
+
 port receiveSentGame : (Value -> msg) -> Sub msg
 
+
 port returnScoreGame : Value -> Cmd msg
+
 
 port receiveReturnedGame : (Value -> msg) -> Sub msg

--- a/frontend/src/ScoringWorker.elm
+++ b/frontend/src/ScoringWorker.elm
@@ -10,7 +10,7 @@ import ScoringPorts exposing (decodeGameFromValue, receiveSentGame, returnScoreG
 
 type Msg
     = ScoreGame Game.Game Int
-    | GenerateSeedForScoring Value
+    | GenerateSeedForScoring Value -- JSON encoded Game
 
 
 init : () -> ( (), Cmd msg )

--- a/frontend/src/ScoringWorker.elm
+++ b/frontend/src/ScoringWorker.elm
@@ -15,6 +15,10 @@ type Msg
 
 init : () -> ( (), Cmd msg )
 init _ =
+    let
+        _ =
+            Debug.log "tag" "starting elm worker"
+    in
     ( (), Cmd.none )
 
 
@@ -24,10 +28,18 @@ update msg _ =
         GenerateSeedForScoring encodedGame ->
             case decodeGameFromValue encodedGame of
                 Ok game ->
+                    let
+                        _ =
+                            Debug.log "tag" "decoded game, now rng"
+                    in
                     ( ()
                     , Random.generate (ScoreGame game) (Random.int 0 42069)
                     )
                 Err error ->
+                    let
+                        _ =
+                            Debug.log "tag" ("Decoding error in score worker elm:" ++ (Json.Decode.errorToString error))
+                    in
                     -- local JSON communication encoding error should never happen...
                     -- there's not much we can do from here either w/o added extra JSON
                     -- data/error field structure around game
@@ -36,8 +48,14 @@ update msg _ =
                     )
         ScoreGame game seed ->
             let
+                _ =
+                    Debug.log "tag" "about to start scoring"
+
                 finalScore =
                     scoreGame game seed
+
+                _ =
+                    Debug.log "tag" "finished scroing game, now sending it back"
 
                 completedGame =
                     Game.setScore finalScore game
@@ -50,9 +68,7 @@ update msg _ =
 
 subscriptions : () -> Sub Msg
 subscriptions _ =
-    Sub.batch
-        [ receiveSentGame GenerateSeedForScoring
-        ]
+    receiveSentGame GenerateSeedForScoring
 
 
 main : Program () () Msg

--- a/frontend/src/ScoringWorker.elm
+++ b/frontend/src/ScoringWorker.elm
@@ -1,0 +1,45 @@
+port module ScoringWorker exposing (main)
+
+import Platform
+import Model.Game as Game
+
+
+type Msg
+    = ScoreGame Game.Game -- TODO: json encode
+
+
+init : () -> ( (), Cmd msg )
+init _ =
+    ( (), Cmd.none )
+
+
+update : Msg -> () -> ( (), Cmd msg )
+update msg _ =
+    case msg of
+        Increment int ->
+            ( (), sendCount (int + 1) )
+
+        Decrement int ->
+            ( (), sendCount (int - 1) )
+
+
+subscriptions : () -> Sub Msg
+subscriptions _ =
+    Sub.batch
+        [ scoreGame ScoreGame
+        ]
+
+
+main : Program () () Msg
+main =
+    Platform.worker { init = init
+                    , update = update
+                    , subscriptions = subscriptions
+                    }
+
+
+-- TODO: json encoded game
+port scoreGame : (Int -> msg) -> Sub msg
+
+
+port sendScoredGame : Int -> Cmd msg

--- a/frontend/static/js/scoring-worker.js.placeholder
+++ b/frontend/static/js/scoring-worker.js.placeholder
@@ -1,0 +1,1 @@
+run `npm run make` to compile the scoring-worker.js file!

--- a/frontend/static/js/worker.js
+++ b/frontend/static/js/worker.js
@@ -2,7 +2,7 @@ importScripts("scoring-worker.js");
 
 const app = Elm.ScoringWorker.init();
 
-// when we receive a msg from main thread, send it to worker's `sendScoreGame` port
+// when we receive a msg from main thread, send it to worker's `receiveSentGame` elm port
 onmessage = function ({ data }) {
   const { type, value } = data;
 

--- a/frontend/static/js/worker.js
+++ b/frontend/static/js/worker.js
@@ -2,18 +2,21 @@ importScripts("scoring-worker.js");
 
 const app = Elm.Worker.init();
 
+// when we receive a msg from main thread, send it to worker's `sendScoreGame` port
 onmessage = function ({ data }) {
   const { type, value } = data;
 
   switch (type) {
     case "score":
-      app.ports.scoreGame.send(value);
+      app.ports.sendScoreGame.send(value);
       break;
     default:
       console.error("Unhandled web worker message: " + type);
   }
 };
 
-app.ports.sendScoredGame.subscribe(function (game) {
+// listen for calls to `returnScoreGame` port, and pass back to main thread
+app.ports.receiveReturnedGame.subscribe(function (game) {
+  console.log(`returning ${game}`)
   postMessage(game);
 });

--- a/frontend/static/js/worker.js
+++ b/frontend/static/js/worker.js
@@ -1,6 +1,8 @@
+console.log("starting web worker")
 importScripts("scoring-worker.js");
 
-const app = Elm.Worker.init();
+console.log("imported scorere script")
+const app = Elm.ScoringWorker.init();
 
 // when we receive a msg from main thread, send it to worker's `sendScoreGame` port
 onmessage = function ({ data }) {
@@ -8,15 +10,20 @@ onmessage = function ({ data }) {
 
   switch (type) {
     case "score":
-      app.ports.sendScoreGame.send(value);
+      console.log("recieving sent game", JSON.stringify(value))
+      app.ports.receiveSentGame.send(value);
       break;
     default:
       console.error("Unhandled web worker message: " + type);
   }
 };
 
+console.log("worker:", app)
+
 // listen for calls to `returnScoreGame` port, and pass back to main thread
-app.ports.receiveReturnedGame.subscribe(function (game) {
+app.ports.returnScoreGame.subscribe(function (game) {
   console.log(`returning ${game}`)
   postMessage(game);
 });
+
+console.log('web worker setup')

--- a/frontend/static/js/worker.js
+++ b/frontend/static/js/worker.js
@@ -1,0 +1,19 @@
+importScripts("scoring-worker.js");
+
+const app = Elm.Worker.init();
+
+onmessage = function ({ data }) {
+  const { type, value } = data;
+
+  switch (type) {
+    case "score":
+      app.ports.scoreGame.send(value);
+      break;
+    default:
+      console.error("Unhandled web worker message: " + type);
+  }
+};
+
+app.ports.sendScoredGame.subscribe(function (game) {
+  postMessage(game);
+});

--- a/frontend/static/js/worker.js
+++ b/frontend/static/js/worker.js
@@ -1,7 +1,5 @@
-console.log("starting web worker")
 importScripts("scoring-worker.js");
 
-console.log("imported scorere script")
 const app = Elm.ScoringWorker.init();
 
 // when we receive a msg from main thread, send it to worker's `sendScoreGame` port
@@ -10,7 +8,6 @@ onmessage = function ({ data }) {
 
   switch (type) {
     case "score":
-      console.log("recieving sent game", JSON.stringify(value))
       app.ports.receiveSentGame.send(value);
       break;
     default:
@@ -18,12 +15,7 @@ onmessage = function ({ data }) {
   }
 };
 
-console.log("worker:", app)
-
 // listen for calls to `returnScoreGame` port, and pass back to main thread
 app.ports.returnScoreGame.subscribe(function (game) {
-  console.log(`returning ${game}`)
   postMessage(game);
 });
-
-console.log('web worker setup')

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -11,6 +11,7 @@
   <body>
     <script src="/static/js/elm.js"></script>
     <script>
+      console.log("starting app")
       // load Web Worker
       const worker = new Worker("/static/js/worker.js");
 
@@ -19,17 +20,18 @@
                                   .find((row) => row.startsWith("ngo_auth_set="))
                                   ?.split("=")[1];
       const app = Elm.Main.init({ flags: authCookieSet !== undefined });
+      console.log("app loadde", app)
 
       // listen for calls to `sendScoreGame` and pass along to web worker
-      app.ports.listenForSendScoreGame.subscribe(function (game) {
+      app.ports.sendScoreGame.subscribe(function (game) {
         console.log(`sending ${game}`)
         worker.postMessage({ type: "score", value: game });
       });
 
-      // listen for `returnScoreGame` responses from web worker
-      worker.onmessage = funciton ({ data }) {
+      // listen for `returnScoreGame` responses from web worker and forward to Elm.Main app
+      worker.onmessage = function ({ data }) {
         console.log(`got returned game ${data}`)
-        app.ports.returnScoreGame.send(data);
+        app.ports.receiveReturnedGame.send(data);
       }
     </script>
     <noscript>This App requires JavaScript.</noscript>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -11,7 +11,6 @@
   <body>
     <script src="/static/js/elm.js"></script>
     <script>
-      console.log("starting app")
       // load Web Worker
       const worker = new Worker("/static/js/worker.js");
 
@@ -20,17 +19,14 @@
                                   .find((row) => row.startsWith("ngo_auth_set="))
                                   ?.split("=")[1];
       const app = Elm.Main.init({ flags: authCookieSet !== undefined });
-      console.log("app loadde", app)
 
       // listen for calls to `sendScoreGame` and pass along to web worker
       app.ports.sendScoreGame.subscribe(function (game) {
-        console.log(`sending ${game}`)
         worker.postMessage({ type: "score", value: game });
       });
 
       // listen for `returnScoreGame` responses from web worker and forward to Elm.Main app
       worker.onmessage = function ({ data }) {
-        console.log(`got returned game ${data}`)
         app.ports.receiveReturnedGame.send(data);
       }
     </script>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -11,11 +11,17 @@
   <body>
     <script src="/static/js/elm.js"></script>
     <script>
+      // load Web Worker
+      const worker = new Worker("/static/js/worker.js");
+
       const authCookieSet = document.cookie
                                   .split("; ")
                                   .find((row) => row.startsWith("ngo_auth_set="))
                                   ?.split("=")[1];
       const app = Elm.Main.init({ flags: authCookieSet !== undefined });
+
+      // TODO: register app ports
+
     </script>
     <noscript>This App requires JavaScript.</noscript>
   </body>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -20,8 +20,17 @@
                                   ?.split("=")[1];
       const app = Elm.Main.init({ flags: authCookieSet !== undefined });
 
-      // TODO: register app ports
+      // listen for calls to `sendScoreGame` and pass along to web worker
+      app.ports.listenForSendScoreGame.subscribe(function (game) {
+        console.log(`sending ${game}`)
+        worker.postMessage({ type: "score", value: game });
+      });
 
+      // listen for `returnScoreGame` responses from web worker
+      worker.onmessage = funciton ({ data }) {
+        console.log(`got returned game ${data}`)
+        app.ports.returnScoreGame.send(data);
+      }
     </script>
     <noscript>This App requires JavaScript.</noscript>
   </body>

--- a/frontend/tests/GameTest.elm
+++ b/frontend/tests/GameTest.elm
@@ -2,6 +2,8 @@ module GameTest exposing (..)
 
 
 import Expect exposing (Expectation)
+import Json.Encode exposing (encode)
+import Json.Decode exposing (decodeValue)
 import Model.Game exposing (..)
 import Model.Board exposing (BoardSize(..))
 import Model.Piece exposing (Piece(..))
@@ -66,4 +68,29 @@ suite =
                     in
                     Expect.equal True (isActiveTurn game)
             ]
+            , describe "JSON coding"
+              [ test "JSON coding works both ways" <|
+                \_ ->
+                    let
+                        game =
+                            newGame Full White 0.0
+                                |> addMoveToHistory (Play BlackStone 0)
+                                |> addMoveToHistory (Pass WhiteStone)
+                                |> addMoveToHistory (Pass BlackStone)
+
+                        encodedGame =
+                            gameEncoder game
+
+                        decodedGame =
+                            decodeValue (gameDecoder) encodedGame
+
+                        _ =
+                            case decodedGame of
+                                Err e ->
+                                    Debug.log "test" (Json.Decode.errorToString e)
+                                _ ->
+                                    Debug.log "test" "no decoding error here"
+                    in
+                    Expect.ok decodedGame
+              ]
         ]

--- a/frontend/tests/GameTest.elm
+++ b/frontend/tests/GameTest.elm
@@ -83,13 +83,6 @@ suite =
 
                         decodedGame =
                             decodeValue (gameDecoder) encodedGame
-
-                        _ =
-                            case decodedGame of
-                                Err e ->
-                                    Debug.log "test" (Json.Decode.errorToString e)
-                                _ ->
-                                    Debug.log "test" "no decoding error here"
                     in
                     Expect.ok decodedGame
               ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format-elm": "npx elm-format frontend/src/ --yes",
     "format-go": "go fmt .",
     "make": "npm run make-elm ; npm run make-go ; npm run make-css",
-    "make-elm": "elm make frontend/src/Main.elm --output frontend/static/js/elm.js",
+    "make-elm": "elm make frontend/src/Main.elm --output frontend/static/js/elm.js && elm make frontend/src/ScoringWorker.elm --output frontend/static/js/scoring-worker.js",
     "make-go": "go build main.go",
     "make-css": "npx tailwindcss -i ./frontend/static/css/raw.css -o ./frontend/static/css/index.css"
   },


### PR DESCRIPTION
closes #72 

Elm can't handle anything in parallel (since JS is single threaded under the hood) and trying to make the scoring logic interruptible w/ Task sounded awful. So this PR adds a simple web worker JS script that runs a headless elm program (i.e. no DOM access) to handle scoring games. The main Elm app and the web worker app communicate via Elm ports that transact  JSON encoded web worker messages between the two apps.

 - [x] Added tests
