### PR TITLE
Multiplayer and turn enforcement

### DIFF
--- a/backend/handler/router/endpoints/signin.go
+++ b/backend/handler/router/endpoints/signin.go
@@ -25,7 +25,7 @@ func (rhandler RouteHandler) Signin(c *gin.Context) {
 	if err != nil {
 		log.Printf("Failed to signin user: %v\n", err)
 		c.JSON(apperrors.Status(err), gin.H{
-			"error": err,
+			"error": err.Error(),
 		})
 		return
 	}
@@ -36,7 +36,7 @@ func (rhandler RouteHandler) Signin(c *gin.Context) {
 		log.Printf("Failed to sign up user: %v\n", err.Error())
 		c.JSON(apperrors.Status(err), gin.H{
 			"ok":    false,
-			"error": err,
+			"error": err.Error(),
 		})
 		return
 	}

--- a/backend/handler/router/endpoints/signup.go
+++ b/backend/handler/router/endpoints/signup.go
@@ -26,10 +26,9 @@ func (rhandler RouteHandler) Signup(c *gin.Context) {
 	user, err := rhandler.Provider.UserService.Signup(c, req.Username, req.Password)
 	if err != nil {
 		log.Printf("Failed to sign up user: %v\n", err.Error())
-		// TODO: i probably shouldnt send the full err back to client
 		c.JSON(apperrors.Status(err), gin.H{
 			"ok":    false,
-			"error": err,
+			"error": err.Error(),
 		})
 		return
 	}
@@ -40,7 +39,7 @@ func (rhandler RouteHandler) Signup(c *gin.Context) {
 		log.Printf("Failed to sign up user: %v\n", err.Error())
 		c.JSON(apperrors.Status(err), gin.H{
 			"ok":    false,
-			"error": err,
+			"error": err.Error(),
 		})
 		return
 	}

--- a/backend/model/game.go
+++ b/backend/model/game.go
@@ -35,3 +35,14 @@ type Game struct {
 	BlackPlayer   User        `gorm:"foreignKey:BlackPlayerId;"`
 	WhitePlayer   User        `gorm:"foreignKey:WhitePlayerId;"`
 }
+
+/**
+ * Update receiver game with only the legally updatable values
+ * from passed `updateGame` values.
+ */
+func (recGame *Game) UpdateLegalValues(updateGame Game) {
+	recGame.History = updateGame.History
+	recGame.Board.Map = updateGame.Board.Map
+	recGame.IsOver = updateGame.IsOver
+	recGame.Score = updateGame.Score
+}

--- a/frontend/src/Model/Game.elm
+++ b/frontend/src/Model/Game.elm
@@ -232,8 +232,8 @@ gameDecoder =
         |> required "playerColor" ColorChoice.colorDecoder
         |> required "isOver" bool
         |> required "score" Score.scoreDecoder
-        |> required "blackPlayerName" string
         |> required "whitePlayerName" string
+        |> required "blackPlayerName" string
         |> required "id" (nullable string)
 
 

--- a/frontend/src/Page/GamePlay.elm
+++ b/frontend/src/Page/GamePlay.elm
@@ -29,7 +29,7 @@ import View.Loading exposing (viewLoading)
 type Msg
     = PlayPiece Int
     | PlayPass
-    | Resign
+    | PlayResign
     | DataReceived (WebData Game)
     | ReceiveScoredGame Value -- JSON encoded Game
     | UpdateGameResponse (Result Http.Error Game)
@@ -164,22 +164,30 @@ scoreView score playerColor =
 
 gamePlayView : Game -> Model -> Html Msg
 gamePlayView game model =
+    let
+        viewPlayOptions =
+            if Game.isActiveTurn game then
+                div [ class "flex gap-4" ]
+                    [ button
+                          [ class "btn"
+                          , onClick PlayPass
+                          ]
+                          [ text "Pass" ]
+                    , button
+                          [ class "btn-base bg-red-500 text-white border-solid border-2 border-red-500 hover:bg-white hover:text-red-500"
+                          , onClick PlayResign
+                          ]
+                          [ text "Resign" ]
+                    ]
+            else
+                text ""
+
+    in
     div [ class "p-5 flex flex-col gap-4" ]
         [ viewWaitForOpponent model.activeTurn
         , viewBuildBoard game
         , viewAlert model
-        , div [ class "flex gap-4" ]
-            [ button
-                [ class "btn"
-                , onClick PlayPass
-                ]
-                [ text "Pass" ]
-            , button
-                [ class "btn-base bg-red-500 text-white border-solid border-2 border-red-500 hover:bg-white hover:text-red-500"
-                , onClick Resign
-                ]
-                [ text "Resign" ]
-            ]
+        , viewPlayOptions
         ]
 
 
@@ -427,14 +435,41 @@ handlePlayPass model =
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    case msg of
-        PlayPiece index ->
+    let
+        isAllowedToPlay =
+            case gameFromModel model of
+                Just game ->
+                    Game.isActiveTurn game
+
+                Nothing ->
+                    False
+
+        makeWaitYourTurnError mdl =
+            { mdl | invalidMoveAlert = Just "Wait for your turn" }
+    in
+    case ( msg, isAllowedToPlay ) of
+        (PlayPiece index, False) ->
+            ( makeWaitYourTurnError model
+            , Cmd.none
+            )
+
+        (PlayPass, False) ->
+            ( makeWaitYourTurnError model
+            , Cmd.none
+            )
+
+        (PlayResign, False) ->
+            ( makeWaitYourTurnError model
+            , Cmd.none
+            )
+
+        (PlayPiece index, True) ->
             handlePlayPiece model index
 
-        PlayPass ->
+        (PlayPass, True) ->
             handlePlayPass model
 
-        Resign ->
+        (PlayResign, True) ->
             let
                 resignedColor =
                     case gameFromModel model of
@@ -447,7 +482,7 @@ update msg model =
             in
             startScoring model resignedColor
 
-        DataReceived responseGame ->
+        (DataReceived responseGame, _) ->
             let
                 activeTurn =
                     case responseGame of
@@ -482,7 +517,7 @@ update msg model =
             , Cmd.none
             )
 
-        ReceiveScoredGame encodedGame ->
+        (ReceiveScoredGame encodedGame, _) ->
             let
                 decodedGame =
                     decodeGameFromValue encodedGame
@@ -513,7 +548,7 @@ update msg model =
             , endTurn updatedModel
             )
 
-        UpdateGameResponse resp ->
+        (UpdateGameResponse resp, _) ->
             case resp of
                 Ok game ->
                     ( { model
@@ -530,7 +565,6 @@ update msg model =
 
 endTurn : Model -> Cmd Msg
 endTurn model =
-    -- TODO: do turn swap
     case gameFromModel model of
         Just game ->
             updateGame model.gameId game UpdateGameResponse

--- a/frontend/src/Page/GamePlay.elm
+++ b/frontend/src/Page/GamePlay.elm
@@ -169,19 +169,19 @@ gamePlayView game model =
             if Game.isActiveTurn game then
                 div [ class "flex gap-4" ]
                     [ button
-                          [ class "btn"
-                          , onClick PlayPass
-                          ]
-                          [ text "Pass" ]
+                        [ class "btn"
+                        , onClick PlayPass
+                        ]
+                        [ text "Pass" ]
                     , button
-                          [ class "btn-base bg-red-500 text-white border-solid border-2 border-red-500 hover:bg-white hover:text-red-500"
-                          , onClick PlayResign
-                          ]
-                          [ text "Resign" ]
+                        [ class "btn-base bg-red-500 text-white border-solid border-2 border-red-500 hover:bg-white hover:text-red-500"
+                        , onClick PlayResign
+                        ]
+                        [ text "Resign" ]
                     ]
+
             else
                 text ""
-
     in
     div [ class "p-5 flex flex-col gap-4" ]
         [ viewWaitForOpponent model.activeTurn
@@ -448,28 +448,28 @@ update msg model =
             { mdl | invalidMoveAlert = Just "Wait for your turn" }
     in
     case ( msg, isAllowedToPlay ) of
-        (PlayPiece index, False) ->
+        ( PlayPiece index, False ) ->
             ( makeWaitYourTurnError model
             , Cmd.none
             )
 
-        (PlayPass, False) ->
+        ( PlayPass, False ) ->
             ( makeWaitYourTurnError model
             , Cmd.none
             )
 
-        (PlayResign, False) ->
+        ( PlayResign, False ) ->
             ( makeWaitYourTurnError model
             , Cmd.none
             )
 
-        (PlayPiece index, True) ->
+        ( PlayPiece index, True ) ->
             handlePlayPiece model index
 
-        (PlayPass, True) ->
+        ( PlayPass, True ) ->
             handlePlayPass model
 
-        (PlayResign, True) ->
+        ( PlayResign, True ) ->
             let
                 resignedColor =
                     case gameFromModel model of
@@ -482,7 +482,7 @@ update msg model =
             in
             startScoring model resignedColor
 
-        (DataReceived responseGame, _) ->
+        ( DataReceived responseGame, _ ) ->
             let
                 activeTurn =
                     case responseGame of
@@ -517,7 +517,7 @@ update msg model =
             , Cmd.none
             )
 
-        (ReceiveScoredGame encodedGame, _) ->
+        ( ReceiveScoredGame encodedGame, _ ) ->
             let
                 decodedGame =
                     decodeGameFromValue encodedGame
@@ -548,7 +548,7 @@ update msg model =
             , endTurn updatedModel
             )
 
-        (UpdateGameResponse resp, _) ->
+        ( UpdateGameResponse resp, _ ) ->
             case resp of
                 Ok game ->
                     ( { model

--- a/frontend/src/Page/GamePlay.elm
+++ b/frontend/src/Page/GamePlay.elm
@@ -80,11 +80,14 @@ startScoring model forfeitColor =
                 completedGame =
                     setScore forfeitScore game
                         |> setIsOver True
+
+                updatedModel =
+                    { model
+                        | clientGameData = Just completedGame
+                    }
             in
-            ( { model
-                | clientGameData = Just completedGame
-              }
-            , endTurn model
+            ( updatedModel
+            , endTurn updatedModel
             )
 
         ( Just game, _ ) ->
@@ -370,8 +373,6 @@ handlePlayPiece model index =
                         { model
                             | clientGameData =
                                 playMove move game
-                                    -- TODO: remove color swap w/ networking
-                                    |> setPlayerColor (colorInverse game.playerColor)
                                     |> Just
                             , activeTurn = not model.activeTurn
                             , invalidMoveAlert = Nothing
@@ -394,8 +395,6 @@ handlePlayPass model =
             let
                 updatedGame =
                     playMove (Move.Pass (colorToPiece game.playerColor)) game
-                        -- TODO remove color swap w/ networking
-                        |> setPlayerColor (colorInverse game.playerColor)
 
                 ( updatedModel, command ) =
                     -- check if game ended by Pass moves


### PR DESCRIPTION
closes #8 
closes #32 

Someone could still manually send payloads to the backend to take multiple turns in a row; this just prevents you from easily doing it from the client.

 - [ ] Added tests
